### PR TITLE
Fix broken select boxes on news admin page

### DIFF
--- a/phx/news/admin.py
+++ b/phx/news/admin.py
@@ -121,6 +121,14 @@ class ThumbnailAdmin(nested_admin.NestedStackedInline):
 
 
 class NewsAdmin(nested_admin.NestedModelAdmin):
+
+    class Media:
+        # select2 must be loaded before jquery.init.js (#62)
+        js = [
+            "admin/js/vendor/select2/select2.full.js",
+            "admin/js/jquery.init.js"
+        ]
+
     list_display = ['current_image', 'title', 'created_date', 'author']
     list_display_links = ['current_image', 'title']
     list_select_related = ['author', 'thumbnail']


### PR DESCRIPTION


Fixes: https://github.com/orangespaceman/phx/issues/62

Noticed a strange issue whilst testing the Django upgrade. Select boxes on the news admin page weren't working and this error appeared in the console:

```
Select2: An instance of jQuery or a jQuery-compatible library was not found. Make sure that you are including jQuery before Select2 on your web page.
```

Found a few similar issues online and ultimately fixed by following this advice: https://github.com/yourlabs/django-autocomplete-light/issues/1137#issuecomment-657036224

The problem essentially is that select2 is being referenced after jquery.init (which: _"sets up jQuery with noConflict, making jQuery available in django.jQuery only and not $._"). So the fix is to force the order. It's unclear why it only happens for the news admin page but I think this is the cause: https://github.com/theatlantic/django-nested-admin/issues/244

Comparison between imports of News and Pages admin pages

![image](https://github.com/orangespaceman/phx/assets/3168140/ccefe23d-9bf8-4697-be66-ac59f051b47a)


Previously select2 was referenced after jquery.init:
![Screenshot from 2024-06-14 09-47-26](https://github.com/orangespaceman/phx/assets/3168140/a3e36330-2866-4d99-aacb-029cc3f74e04)

Now it's referenced after:
![Screenshot from 2024-06-14 10-39-33](https://github.com/orangespaceman/phx/assets/3168140/872f2c2b-7447-4111-9b77-e1ef890dc508)

Select boxes now working:
![Screenshot from 2024-06-14 10-40-00](https://github.com/orangespaceman/phx/assets/3168140/d1e25ced-71b6-4593-9f3e-40e04db4d9c4)


