### PR TITLE
Format new results columns to make it easier to copy paste them (#67)

### DIFF
--- a/phx/results/results_processor.py
+++ b/phx/results/results_processor.py
@@ -26,12 +26,27 @@ class ResultsProcessor:
         prev_results = prev_workbook["Results (30 days)"]
 
         sheet = curr_workbook.create_sheet(title="NEW RESULTS", index=0)
+        sheet = self._append_headers(sheet)
         self._append_new_rows(curr_results, prev_results, sheet)
 
         self.results = curr_workbook
 
+    def _append_headers(self, sheet):
+        sheet.append([
+            "Name",
+            "Category",
+            "Distance",
+            "Position",
+            "Time",
+            "Date",
+            "Race",
+            "Location",
+        ])
+
+        return sheet
+
     def _append_new_rows(self, curr_results, prev_results, sheet):
-        for row in curr_results.iter_rows(values_only=True):
+        for row in curr_results.iter_rows(values_only=True, min_row=2):
             row = self._normalize_row(row)
             if row[5] == "parkrun":
                 continue
@@ -45,7 +60,7 @@ class ResultsProcessor:
                     break
 
             if not seen:
-                sheet.append(row)
+                sheet.append(self._format_row(row))
 
         return sheet
 
@@ -54,6 +69,37 @@ class ResultsProcessor:
 
         row = tuple(c.strip() if isinstance(c, str) else c for c in row)
         return tuple(None if c == "" else c for c in row)
+
+    def _format_row(self, row):
+        [
+            first_name,
+            surname,
+            sex,
+            age_category,
+            date,
+            distance,
+            race,
+            location,
+            overall_position,
+            _age_position,
+            gender_postion,
+            _best,
+            _age_grading,
+            _club_record,
+            time,
+        ] = row
+
+        position = gender_postion if gender_postion else overall_position
+        return [
+            f"{first_name} {surname}",
+            f"{sex}{age_category}",
+            distance,
+            position,
+            time,
+            date,
+            race,
+            location,
+        ]
 
     def save(self, filename):
         if self.results is not None:

--- a/phx/results/results_processor.py
+++ b/phx/results/results_processor.py
@@ -33,14 +33,8 @@ class ResultsProcessor:
 
     def _append_headers(self, sheet):
         sheet.append([
-            "Name",
-            "Category",
-            "Distance",
-            "Position",
-            "Time",
-            "Date",
-            "Race",
-            "Location",
+            "Name", "Category", "Distance", "Position", "Time", "Date", "Race",
+            "Location", "Overall Position", "Age Position", "Gender Position"
         ])
 
         return sheet
@@ -81,7 +75,7 @@ class ResultsProcessor:
             race,
             location,
             overall_position,
-            _age_position,
+            age_position,
             gender_postion,
             _best,
             _age_grading,
@@ -91,14 +85,9 @@ class ResultsProcessor:
 
         position = gender_postion if gender_postion else overall_position
         return [
-            f"{first_name} {surname}",
-            f"{sex}{age_category}",
-            distance,
-            position,
-            time,
-            date,
-            race,
-            location,
+            f"{first_name} {surname}", f"{sex}{age_category}", distance,
+            position, time, date, race, location, overall_position,
+            age_position, gender_postion
         ]
 
     def save(self, filename):

--- a/phx/results/tests/test_results_processor.py
+++ b/phx/results/tests/test_results_processor.py
@@ -107,7 +107,7 @@ class TestProcessResults(TestCase):
             prev, curr = (fake_results(10), fake_results(10))
             [
                 first_name, surname, sex, age_category, date, distance, race,
-                location, _, _, position, _, _, _, time
+                location, position, age_pos, gen_pos, _, _, _, time
             ] = new_result = fake_result()
             curr["Results (30 days)"].append(new_result)
 
@@ -121,28 +121,17 @@ class TestProcessResults(TestCase):
             new_results = list(sheet.rows)
             headers = list(cell.value for cell in new_results[0])
             expected_headers = [
-                "Name",
-                "Category",
-                "Distance",
-                "Position",
-                "Time",
-                "Date",
-                "Race",
-                "Location",
+                "Name", "Category", "Distance", "Position", "Time", "Date",
+                "Race", "Location", "Overall Position", "Age Position",
+                "Gender Position"
             ]
 
             self.assertEqual(headers, expected_headers)
 
             result = list(cell.value for cell in new_results[1])
             expected_result = [
-                f"{first_name} {surname}",
-                f"{sex}{age_category}",
-                distance,
-                position,
-                time,
-                date,
-                race,
-                location,
+                f"{first_name} {surname}", f"{sex}{age_category}", distance,
+                gen_pos, time, date, race, location, position, age_pos, gen_pos
             ]
 
             self.assertEqual(result, expected_result)

--- a/phx/results/tests/test_results_processor.py
+++ b/phx/results/tests/test_results_processor.py
@@ -105,7 +105,10 @@ class TestProcessResults(TestCase):
 
         with patch("results.results_processor.load_workbook") as mock:
             prev, curr = (fake_results(10), fake_results(10))
-            new_result = fake_result()  # one new result
+            [
+                first_name, surname, sex, age_category, date, distance, race,
+                location, _, _, position, _, _, _, time
+            ] = new_result = fake_result()
             curr["Results (30 days)"].append(new_result)
 
             mock.side_effect = [curr, prev]
@@ -115,8 +118,34 @@ class TestProcessResults(TestCase):
 
             assert processor.results is not None
             sheet = processor.results["NEW RESULTS"]
-            self.assertEqual(2, len(list(sheet.rows)))
-            self.assertEqual(new_result, list(sheet.values)[1])
+            new_results = list(sheet.rows)
+            headers = list(cell.value for cell in new_results[0])
+            expected_headers = [
+                "Name",
+                "Category",
+                "Distance",
+                "Position",
+                "Time",
+                "Date",
+                "Race",
+                "Location",
+            ]
+
+            self.assertEqual(headers, expected_headers)
+
+            result = list(cell.value for cell in new_results[1])
+            expected_result = [
+                f"{first_name} {surname}",
+                f"{sex}{age_category}",
+                distance,
+                position,
+                time,
+                date,
+                race,
+                location,
+            ]
+
+            self.assertEqual(result, expected_result)
 
     def test_process_ignores_parkruns(self):
         old_file = File.objects.create(file="BrightonPhoenix_2024-05-05.xlsx")


### PR DESCRIPTION
Formats the columns in the NEW_RESULTS sheet so that it's slightly easier to copy paste them onto the site.

Specifically:

- Combines the firstname and surname columns
- Combines the sex and category columns
- Prefers the gender position if available
- Makes Name Category, Distance, Position and Time the first five columns (the ones to copy) 
- Includes Date, Race and Location for context

Looks a bit like:

![image](https://github.com/orangespaceman/phx/assets/3168140/174023f9-3e5f-4905-917a-e3b58f5176ec)
