### PR TITLE
Adds a job to scrape athletes from PowerOf10

### DIFF
--- a/phx/athletes/athlete_scraper.py
+++ b/phx/athletes/athlete_scraper.py
@@ -1,0 +1,93 @@
+import re
+from string import ascii_lowercase
+
+import requests
+from athletes.models import Athlete
+from bs4 import BeautifulSoup
+
+
+class AtheleteScraper:
+
+    ATHLETE_LOOKUP_URL = "https://www.thepowerof10.info/athletes/" \
+                         "athleteslookup.aspx?surname={surname}" \
+                         "&firstname=&club=Brighton+Phoenix"
+
+    def __init__(self):
+        self.athletes = []
+
+    def find_athletes(self):
+        """
+        Seatch Power of 10 for all Brighton Phoenix athletes.
+
+        Returns the total number of athletes found
+        """
+
+        self.athletes = []
+
+        for c in ascii_lowercase:
+            athletes = self.find_by_surname(c)
+            self.athletes.extend(athletes)
+
+        return len(self.athletes)
+
+    def find_by_surname(self, surname):
+        url = AtheleteScraper.ATHLETE_LOOKUP_URL.format(surname=surname)
+        print("Scraping {url}".format(url=url))
+
+        page = requests.get(url)
+
+        return self._parse_page(page)
+
+    def _parse_page(self, page):
+        soup = BeautifulSoup(page.content, "html.parser")
+
+        table = soup.select('div[id$=Results]')
+        rows = self._parse_results_table(table)
+        athletes = self._parse_rows(rows)
+
+        return athletes
+
+    def _parse_results_table(self, table):
+        if len(table) == 1:
+            return table[0].find_all('tr')
+
+        print(f"Expected a single results table, found {len(table)}")
+
+        return []
+
+    def _parse_rows(self, rows):
+        athletes = []
+
+        # Parse each row, ignoring the header
+        for row in rows[1:]:
+            athlete = self._parse_row(row)
+            if athlete:
+                athletes.append(athlete)
+
+        return athletes
+
+    def _parse_row(self, row):
+        cells = row.find_all('td')
+
+        if (len(cells) == 9):
+            return Athlete(first_name=cells[0].text.strip(),
+                           last_name=cells[1].text.strip(),
+                           age_category=cells[3].text.strip(),
+                           gender=cells[5].text.strip(),
+                           power_of_10_id=self._parse_power_of_10_id(cells[7]))
+
+        return None
+
+    def _parse_power_of_10_id(self, cell):
+        match = re.search(r'profile\.aspx\?athleteid=(\d+)', str(cell))
+        return match.group(1) if match else None
+
+    def save(self):
+        Athlete.objects.bulk_create(self.athletes,
+                                    update_conflicts=True,
+                                    update_fields=[
+                                        "first_name", "last_name",
+                                        "age_category", "gender"
+                                    ],
+                                    unique_fields=["power_of_10_id"])
+        pass

--- a/phx/athletes/athlete_scraper.py
+++ b/phx/athletes/athlete_scraper.py
@@ -1,9 +1,12 @@
+import logging
 import re
 from string import ascii_lowercase
 
 import requests
 from athletes.models import Athlete
 from bs4 import BeautifulSoup
+
+logger = logging.getLogger(__name__)
 
 
 class AtheleteScraper:
@@ -32,7 +35,7 @@ class AtheleteScraper:
 
     def find_by_surname(self, surname):
         url = AtheleteScraper.ATHLETE_LOOKUP_URL.format(surname=surname)
-        print("Scraping {url}".format(url=url))
+        logger.info("Scraping {url}".format(url=url))
 
         page = requests.get(url)
 
@@ -83,11 +86,11 @@ class AtheleteScraper:
         return match.group(1) if match else None
 
     def save(self):
-        Athlete.objects.bulk_create(self.athletes,
-                                    update_conflicts=True,
-                                    update_fields=[
-                                        "first_name", "last_name",
-                                        "age_category", "gender"
-                                    ],
-                                    unique_fields=["power_of_10_id"])
-        pass
+        created = Athlete.objects.bulk_create(self.athletes,
+                                              update_conflicts=True,
+                                              update_fields=[
+                                                  "first_name", "last_name",
+                                                  "age_category", "gender"
+                                              ],
+                                              unique_fields=["power_of_10_id"])
+        return len(created)

--- a/phx/athletes/tests/test_athlete_scraper.py
+++ b/phx/athletes/tests/test_athlete_scraper.py
@@ -1,0 +1,149 @@
+from itertools import groupby
+from pathlib import Path
+
+import responses
+from athletes.athlete_scraper import AtheleteScraper
+from athletes.models import Athlete
+from django.test import TestCase
+from faker import Faker
+
+fake = Faker()
+
+
+class TestAthleteScraper(TestCase):
+
+    @responses.activate
+    def test_handles_empty_results_page(self):
+        self.setup_athletes([])
+        scraper = AtheleteScraper()
+
+        self.assertEqual([], scraper.find_by_surname('x'))
+
+    @responses.activate
+    def test_handles_non_empty_results_page(self):
+        self.setup_athletes(["Jane Doe", "Steve Ovett"])
+
+        scraper = AtheleteScraper()
+        athletes = scraper.find_by_surname('o')
+
+        self.assertEqual(len(athletes), 1)
+        self.assertEqual(athletes[0].first_name, "Steve")
+        self.assertEqual(athletes[0].last_name, "Ovett")
+
+    @responses.activate
+    def test_finds_all_athletes_by_first_letter_and_returns_count(self):
+        self.setup_athletes(["Jane Doe", "John Smith", "Steve Ovett"])
+
+        scraper = AtheleteScraper()
+
+        self.assertEqual(scraper.find_athletes(), 3)
+
+    @responses.activate
+    def test_strips_whitespace_from_athlete_details(self):
+        self.setup_athletes(["  Jane  Doe  "])
+
+        scraper = AtheleteScraper()
+
+        athletes = scraper.find_by_surname('d')
+        self.assertEqual(athletes[0].first_name, "Jane")
+        self.assertEqual(athletes[0].last_name, "Doe")
+
+    @responses.activate
+    def test_extracts_power_of_10_id_from_link(self):
+        self.setup_athletes(["Jane Doe"])
+
+        scraper = AtheleteScraper()
+
+        athletes = scraper.find_by_surname('d')
+        self.assertEqual(athletes[0].power_of_10_id, '8968')
+
+    @responses.activate
+    def test_stores_new_athletes_in_database(self):
+        self.setup_athletes(["Jane Doe"])
+
+        scraper = AtheleteScraper()
+
+        scraper.find_athletes()
+        scraper.save()
+
+        results = Athlete.objects.all()
+        self.assertEqual(1, results.count())
+        self.assertEqual(["Jane"], list(map(lambda a: a.first_name, results)))
+
+    @responses.activate
+    def test_updates_existing_athletes_in_database(self):
+        self.setup_athletes(["Jane Doe"])
+        scraper = AtheleteScraper()
+
+        scraper.find_athletes()
+        scraper.save()
+
+        self.setup_athletes(["Jane Doe", "John Smith"])
+        scraper.find_athletes()
+        scraper.save()
+
+        results = Athlete.objects.all()
+
+        print(list(map(lambda a: a.power_of_10_id, results)))
+        self.assertEqual(2, results.count())
+        self.assertEqual(["Jane", "John"],
+                         list(map(lambda a: a.first_name, results)))
+
+    def setup_athletes(self, athletes, seed=1981):
+        """
+        Setup fake athletes for testing.
+
+        Given a list of "First Last" athlete names, this method will setup
+        fake responses for the Power of 10 athlete lookup page. The gender,
+        age categories and power of 10 ids are randomly generated.
+        """
+        fake.seed_instance(seed)
+
+        path = Path(__file__).with_name('test_body.html')
+        template = path.read_text()
+
+        # Group by first letter of surname
+        for (letter, athletes) in groupby(athletes, lambda x: x.split()[1][0]):
+            rows = ""
+            for athlete in athletes:
+                [first_name, last_name] = athlete.split()
+                rows += """
+                <tr>
+                    <td>{first_name}</td>
+                    <td>{last_name}</td>
+                    <td>{age_category}</td>
+                    <td>{age_category}</td>
+                    <td>{age_category}</td>
+                    <td>{gender}</td>
+                    <td>Brighton Phoenix</td>
+                    <td align="center">
+                    <a href="profile.aspx?athleteid={power_of_10_id}">Show</a>
+                    </td>
+                    <td align="center">
+                    <a href="https://www.runbritainrankings.com/""" \
+                    """runners/profile.aspx?athleteid={power_of_10_id}">Show</a>
+                    </td>
+                </tr>
+                """.format(first_name=first_name,
+                           last_name=last_name,
+                           age_category=fake.random_element(
+                               ["U13", "SEN", "V35", "V50", "V60"]),
+                           gender=fake.random_element(["M", "F"]),
+                           power_of_10_id=fake.random_int())
+
+            responses.get(
+                "https://www.thepowerof10.info/athletes/athleteslookup.aspx?"
+                "surname={letter}&firstname=&club=Brighton+Phoenix".format(
+                    letter=letter.lower()),
+                body=template.replace("{rows}", rows),
+                content_type="text/plain",
+                status=200,
+            )
+
+        # Default response for any other letter
+        responses.get(
+            "https://www.thepowerof10.info/athletes/athleteslookup.aspx",
+            body=template.replace("{rows}", ""),
+            content_type="text/plain",
+            status=200,
+        )

--- a/phx/athletes/tests/test_athlete_scraper.py
+++ b/phx/athletes/tests/test_athlete_scraper.py
@@ -80,11 +80,12 @@ class TestAthleteScraper(TestCase):
 
         self.setup_athletes(["Jane Doe", "John Smith"])
         scraper.find_athletes()
-        scraper.save()
+        # Updates two athletes
+        self.assertEqual(2, scraper.save())
 
         results = Athlete.objects.all()
 
-        print(list(map(lambda a: a.power_of_10_id, results)))
+        # Does not create a second Jane Doe
         self.assertEqual(2, results.count())
         self.assertEqual(["Jane", "John"],
                          list(map(lambda a: a.first_name, results)))

--- a/phx/athletes/tests/test_body.html
+++ b/phx/athletes/tests/test_body.html
@@ -1,0 +1,360 @@
+
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<html>
+<head><title>
+	Athletes Lookup
+</title><link href="/stylesheets/pot.css" type="text/css" rel="stylesheet" /><link rel="stylesheet" href="/stylesheets/jquerydialog.css" type="text/css" />
+
+    <script language="javascript" type="text/javascript" src="/js/jquery.min.js"></script>
+
+    <script language="javascript" type="text/javascript" src="/js/jquery-ui.min.js"></script>
+
+    <script language="javascript" type="text/javascript" src="/js/jquery.tablesorter.min.js"></script>
+
+    <!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZG55J6QWGK"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-ZG55J6QWGK');
+</script>
+
+    
+</head>
+<body>
+    <form method="post" action="./athleteslookup.aspx?surname=&amp;firstname=&amp;club=Brighton+Phoenix" onkeypress="javascript:return WebForm_FireDefaultButton(event, 'cphBody_btnLookup')" id="form1">
+<div class="aspNetHidden">
+<input type="hidden" name="__EVENTTARGET" id="__EVENTTARGET" value="" />
+<input type="hidden" name="__EVENTARGUMENT" id="__EVENTARGUMENT" value="" />
+<input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="/wEPDwULLTE4NjU1ODAzNTAPZBYCZg9kFgQCAQ9kFgQCAQ8WAh4EVGV4dAVFPGxpbmsgaHJlZj0iL3N0eWxlc2hlZXRzL3BvdC5jc3MiIHR5cGU9InRleHQvY3NzIiByZWw9InN0eWxlc2hlZXQiIC8+ZAIED2QWAmYPFgIfAAWgAjwhLS0gR29vZ2xlIHRhZyAoZ3RhZy5qcykgLS0+DTxzY3JpcHQgYXN5bmMgc3JjPSJodHRwczovL3d3dy5nb29nbGV0YWdtYW5hZ2VyLmNvbS9ndGFnL2pzP2lkPUctWkc1NUo2UVdHSyI+PC9zY3JpcHQ+DTxzY3JpcHQ+DSAgd2luZG93LmRhdGFMYXllciA9IHdpbmRvdy5kYXRhTGF5ZXIgfHwgW107DSAgZnVuY3Rpb24gZ3RhZygpe2RhdGFMYXllci5wdXNoKGFyZ3VtZW50cyk7fQ0gIGd0YWcoJ2pzJywgbmV3IERhdGUoKSk7DQ0gIGd0YWcoJ2NvbmZpZycsICdHLVpHNTVKNlFXR0snKTsNPC9zY3JpcHQ+DWQCAw9kFggCAQ9kFghmDxYCHwAFXTxkaXYgYWxpZ249ImNlbnRlciI+DTx0YWJsZSB3aWR0aD0iOTc1cHgiIGJvcmRlcj0iMCIgY2VsbHBhZGRpbmc9IjAiIGNlbGxzcGFjaW5nPSIwIj48dHI+PHRkPmQCAg8PFgIeB1Zpc2libGVoZGQCBA8PFgIfAWhkZAIGD2QWBAIBD2QWAgIBD2QWAgIBDxYCHwBlZAIDDw8WAh8BaGRkAgMPFgIfAAUZPGRpdiBpZD0icG5sTWFpbkdlbmVyYWwiPmQCBw8WAh8ABQY8L2Rpdj5kAgkPZBYGZg8PFgIfAWhkZAICDw8WAh8BaGRkAgYPFgIfAAUZPC90ZD48L3RyPjwvdGFibGU+DTwvZGl2PmRkS1ct7l95rXem+A3I21iixPL+5TzOxM/z9fRabue52fc=" />
+</div>
+
+<script type="text/javascript">
+//<![CDATA[
+var theForm = document.forms['form1'];
+if (!theForm) {
+    theForm = document.form1;
+}
+function __doPostBack(eventTarget, eventArgument) {
+    if (!theForm.onsubmit || (theForm.onsubmit() != false)) {
+        theForm.__EVENTTARGET.value = eventTarget;
+        theForm.__EVENTARGUMENT.value = eventArgument;
+        theForm.submit();
+    }
+}
+//]]>
+</script>
+
+
+<script src="/WebResource.axd?d=gJhnwHtdIWJ90nb7Pt_Dl_OxyVQepiRJz68stt2NBAiUogwwMcY-UEnGbsgdXxSjc8L-JTLSY5Yqz7E2BxhUpQ4gZqp-nRwFqyuUgC9dEjs1&amp;t=638259444720000000" type="text/javascript"></script>
+
+<div class="aspNetHidden">
+
+	<input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="5B00603F" />
+	<input type="hidden" name="__EVENTVALIDATION" id="__EVENTVALIDATION" value="/wEdAAVAddRrIgHVBxqTnawVSH+TdUlozMw+XZ3+UWdvMhsTAmQj0DLWnP8oOqbyrK/5AAH/C7sCi1h0F/C/L8tA/A3inpMCayQEdmiZvs/e7phEZAIY0tNcd5SjRLi9/amRBo+BE5NNynTIBXmZGWGzVKQ6" />
+</div>
+    <div align="center">
+<table width="975px" border="0" cellpadding="0" cellspacing="0"><tr><td>
+
+
+<div id="banner_pnlPOT">
+	
+    <div id="banner_pnlPOTBanner">
+		
+        <table width="100%" border="0" cellpadding="0" cellspacing="0" style="background-color: Black;">
+            <tr>
+                <td>
+                    <div id="banner">
+                        <div id="banner-pot">
+                            <img src="/images/pot/banner-pot.png" alt="Power of 10" />
+                        </div>
+                        <div id="banner-uka">
+                            <a href="http://www.britishathletics.org.uk/">
+                                <img src="/images/pot/britishathletics.png" alt="British Athletics" /></a>
+                        </div>
+                    </div>
+                </td>
+            </tr>
+        </table>
+        <table style="font-family: verdana, arial; background-color: black;" cellspacing="0"
+            cellpadding="0" width="100%" border="0">
+            <tr>
+                <div id="banner_pnlPOTToolbarMain">
+			
+                    <td>
+                        <ul id="potmenu">
+                            <li><a href="/" class="home">Home</a></li>
+                            <li><a href="/aboutpowerof10/" class="about">About</a></li>
+                            <li><a href="/rankings/" class="rankings">Rankings</a></li>
+                            <li><a href="/athletes/athleteslookup.aspx" class="athletes">Athletes</a></li>
+                            <li><a href="/coaches/coacheslookup.aspx" class="coaches">Coaches</a></li>
+                            <li><a href="/clubs/" class="clubs">Clubs</a></li>
+                            <li><a href="/results/highlights.aspx" class="highlights">Highlights</a></li>
+                            <li><a href="/results/resultslookup.aspx" class="results">Results</a></li>
+                            <li><a href="/awards/" class="award">Awards</a></li>
+                            <li><a href="/help/" class="help">Help</a></li>
+                            <li><a href="/user/potuserlogin.aspx" class="login">Login/Register</a></li>
+                            
+                        </ul>
+                    </td>
+                
+		</div>
+            </tr>
+        </table>
+    
+	</div>
+    
+
+</div>
+
+    <div id="pnlMainGeneral">
+    
+    <div id="pnlMain">
+        <table>
+            <tr>
+                <td width="100">
+                    <h2>Athletes</h2>
+                </td>
+                <td>
+                    <b>Surname</b>
+                </td>
+                <td>
+                    <input name="ctl00$cphBody$txtSurname" type="text" value="z" maxlength="50" size="20" id="cphBody_txtSurname" />
+                </td>
+                <td style="white-space: nowrap;">
+                    <b>First Name</b>
+                </td>
+                <td>
+                    <input name="ctl00$cphBody$txtFirstName" type="text" maxlength="50" size="10" id="cphBody_txtFirstName" />
+                </td>
+                <td>
+                    <b>Club</b>
+                </td>
+                <td>
+                    <input name="ctl00$cphBody$txtClub" type="text" value="Brighton Phoenix" maxlength="50" size="30" id="cphBody_txtClub" />
+                </td>
+                <td>
+                    <input type="submit" name="ctl00$cphBody$btnLookup" value="Lookup" id="cphBody_btnLookup" />
+                </td>
+                <td style="white-space: nowrap;">
+                    <a href="/content/itemdisplay.aspx?itemid=33">Who can I lookup?</a>
+                </td>
+            </tr>
+        </table>
+        <table>
+            <tr>
+                <td>
+                    <span id="cphBody_lblRequestErrorMessage" style="color:Red;"></span>
+                </td>
+            </tr>
+        </table>
+        <br />
+        <div id="cphBody_pnlResults">
+	
+            <table cellspacing="0" cellpadding="3" id="cphBody_dgAthletes" style="width:100%;border-collapse:collapse;">
+		<tr style="background-color:Transparent;font-weight:bold;">
+			<td>First</td><td>Surname</td><td>Track</td><td>Road</td><td>XC</td><td>Sex</td><td>Club</td><td align="center">Profile</td><td align="center">runbritain</td>
+		</tr>
+        {rows}
+	</table>
+            <table>
+                <tr>
+                    <td>
+                        <span id="cphBody_lblResultsErrorMessage"></span>
+                    </td>
+                </tr>
+            </table>
+        
+</div>
+        <div style="float: left; width: 100%; border-top: 1px #d0d0d0 dashed; padding: 10px 0">
+            <div style="float: left; width: 100%; margin-bottom: 10px; font-weight: bold; color: #00367c; font-size: 140%">
+                Athletes funded by British Athletics 2024
+            </div>
+            <div style="float: left; width: 450px">
+                <div style="width: 100%; margin-bottom: 10px; font-weight: bold; font-size: 120%">
+                    <b>Podium</b>
+                </div>
+                <div style="float: left; width: 34%">
+                    <b>Olympic</b><br />
+                    <br />
+                    <a href="/athletes/profile.aspx?athleteid=46473">Dina Asher-Smith</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=36079">Holly Bradshaw</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=277349">Molly Caudery</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=525443">Keely Hodgkinson</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=26069">Matthew Hudson-Smith</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=746035">Zharnel Hughes</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=21167">Katarina Johnson-Thompson</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=81741">Josh Kerr</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=53762">Morgan Lake</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=19602">Laura Muir</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=52253">Daryll Neita</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=444384">Ben Pattison</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=217390">Jemma Reekie</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=26042">Jazmin Sawyers</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=746072">Cindy Sember</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=34826">Katie Snowden</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=63342">Jake Wightman</a><br />
+                </div>
+                <div style="float: left; width: 33%">
+                    <b>Relay</b><br />
+                    <br />
+                    <a href="/athletes/profile.aspx?athleteid=41773">Eugene Amo-Dadzie</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=628028">Jeremiah Azu</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=116795">Joseph Brier</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=222626">Lewis Davey</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=437305">Charlie Dobson</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=446147">Jona Efoloko</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=208735">Adam Gemili</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=634495">Alex Haydock-Wilson</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=228003">Imani Lansiquot</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=203603">Rio Mitcham</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=31044">Nethaneel Mitchell-Blake</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=84930">Laviai Nielsen</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=38691">Victoria Ohuruogu</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=20106">Asha Philip</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=47196">Ama Pipi</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=36744">Bianca Williams</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=26161">Jodie Williams</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=1055738">Nicole Yeargin</a><br />
+                </div>
+                <div style="float: left; width: 33%">
+                    <b>Paralympic</b><br />
+                    <br />
+                    <a href="/athletes/profile.aspx?athleteid=529102">Kare Adenegan</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=72290">Hollie Arnold</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=287156">Columba Blango</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=415268">Olivia Breen</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=85951">Jonathan Broom-Edwards</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=91610">Hannah Cockroft</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=75992">Aled Davies</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=81906">Sabrina Fortune</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=27941">Dan Greaves</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=535852">Sophie Hahn</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=445041">Samantha Kinghorn</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=406256">Maria Lyle</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=105919">Owen Miller</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=106240">Jonnie Peacock</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=25085">Dan Pembroke</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=713959">Ben Sandilands</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=457187">Zachary Shaw</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=714686">Daniel Sidbury</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=695203">Zac Skinner</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=623714">Thomas Young</a><br />
+                </div>
+            </div>
+            <div style="float: left; width: 242px;">
+                <div style="width: 100%; margin-bottom: 10px; font-weight: bold; font-size: 120%">
+                    <b>Potential</b>
+                </div>
+                <div style="float: left; width: 53%">
+                    <b>Olympic</b><br />
+                    <br />
+                    <a href="/athletes/profile.aspx?athleteid=37957">Elizabeth Bird</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=17903">Melissa Courtney-Bryant</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=451053">Tom Gale</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=155067">Elliot Giles</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=37208">Neil Gourley</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=186398">Jake Heyward</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=22920">Jessie Knight</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=6313">Eilish McColgan</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=424233">Naomi Metzger</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=439836">George Mills</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=521497">Jade O'Dowda</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=31821">Lawrence Okoye</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=434448">Aimee Pratt</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=331627">Anna Purchase</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=12554">Charlotte Purdue</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=113232">Daniel Rowden</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=51232">Marc Scott</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=28247">Jessica Warner-Judd</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=548255">Callum Wilkinson</a><br />
+                </div>
+                <div style="float: left; width: 47%">
+                    <b>Paralympic</b><br />
+                    <br />
+                    <a href="/athletes/profile.aspx?athleteid=977969">Fabienne Andre</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=95313">Lydia Church</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=640386">Nathan Maguire</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=377560">Anna Nicholson</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=650578">Luke Nuttall</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=119335">Derek Rae</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=656619">Eden Rainbow-Cooper</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=829550">Kevin Santos</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=855082">Ali Smith</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=620583">John Boy Smith</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=57708">Hannah Taunton</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=771696">Harrison Walsh</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=85441">David Weir</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=1010142">Melanie Woods</a><br />
+                </div>
+            </div>
+            <div style="float: left; width: 242px;">
+                <div style="width: 100%; margin-bottom: 10px; font-weight: bold; font-size: 120%">
+                    <b>Confirmation</b>
+                </div>
+                <div style="float: left; width: 45%">
+                    <b>Olympic</b><br />
+                    <br />
+                    <a href="/athletes/profile.aspx?athleteid=83471">Ellie Baker</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=556235">Max Burgin</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=110447">Emile Cairess</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=203633">Lucy Hadaway</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=969051">Samantha Harrison</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=548922">Charlotte Payne</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=105614">Tade Ojora</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=516072">Matthew Stonier</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=442413">Joshua Zeller</a><br />
+                    <br />
+                    <b>Relay</b><br />
+                    <br />
+                    <a href="/athletes/profile.aspx?athleteid=206547">Amber Anning</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=684203">Alyson Bell</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=880785">Yemi Mary John</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=748439">Aleeya Sibbons</a><br />
+                    </div>
+                <div style="float: left; width: 55%">
+                    <b>Paralympic</b><br />
+                    <br />
+                    <a href="/athletes/profile.aspx?athleteid=855539">John Bridge</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=897701">Barney Corrall</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=604314">Ethan Kirby</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=1137942">Oluwafunmilola Oduwaiye</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=857501">Emmanuel Oyinbo-Coker</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=1076220">Marcus Perrineau-Daley</a><br />
+                    <a href="/athletes/profile.aspx?athleteid=528685">Steven Stone</a><br />
+                </div>
+            </div>
+            <div style="clear: both;">
+            </div>
+        </div>
+    </div>
+
+    </div>
+    
+
+<div id="footer_pnlPOT">
+	
+    <table width="100%" style="background-color:Black; color:White;height:88px">
+        <tr>
+            <td align="center" valign="bottom" style="padding-bottom:8px;">
+                <a class="whitetextlink" href="http://www.uka.org.uk">UK Athletics</a>&nbsp;|&nbsp;
+                <a class="whitetextlink" href="http://www.englandathletics.org/">England Athletics</a>&nbsp;|&nbsp;
+                <a class="whitetextlink" href="http://www.scottishathletics.org.uk/">Scottish Athletics</a>&nbsp;|&nbsp;
+                <a class="whitetextlink" href="http://www.niathletics.org/opencontent/default.asp">Athletics Northern Ireland</a>&nbsp;|&nbsp;
+                <a class="whitetextlink" href="http://www.welshathletics.org/">Welsh Athletics</a>&nbsp;|&nbsp;
+                <a class="whitetextlink" href="/aboutpowerof10/privacypolicy.aspx">Privacy Policy</a>
+            </td>
+            <td align="right" valign="bottom"><img src="/images/pot/pot-footer2.png" border="0" /></a></td>
+        </tr>
+    </table>
+
+</div>
+</td></tr></table>
+</div>
+    </form>
+    
+</body>
+</html>

--- a/phx/results/jobs/weekly/update_athletes.py
+++ b/phx/results/jobs/weekly/update_athletes.py
@@ -1,0 +1,14 @@
+from athletes.athlete_scraper import AtheleteScraper
+from django_extensions.management.jobs import WeeklyJob
+
+
+class Job(WeeklyJob):
+    help = "Scrape Power Of 10 to find new Phoenix athletes"
+
+    def execute(self):
+
+        scraper = AtheleteScraper()
+        total_atheletes = scraper.find_athletes()
+
+        if (total_atheletes > 0):
+            scraper.save()

--- a/phx/results/jobs/weekly/update_athletes.py
+++ b/phx/results/jobs/weekly/update_athletes.py
@@ -1,5 +1,9 @@
+import logging
+
 from athletes.athlete_scraper import AtheleteScraper
 from django_extensions.management.jobs import WeeklyJob
+
+logger = logging.getLogger(__name__)
 
 
 class Job(WeeklyJob):
@@ -10,5 +14,8 @@ class Job(WeeklyJob):
         scraper = AtheleteScraper()
         total_atheletes = scraper.find_athletes()
 
+        logger.info(f"Found {total_atheletes} athletes")
+
         if (total_atheletes > 0):
-            scraper.save()
+            saved_athletes = scraper.save()
+            logger.info(f"Inserted or updated {saved_athletes} athletes")

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -10,3 +10,4 @@ facebook-sdk
 psycopg2-binary
 twitter
 openpyxl
+beautifulsoup4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,6 +6,8 @@
 #
 asgiref==3.8.1
     # via django
+beautifulsoup4==4.12.3
+    # via -r base.in
 certifi==2024.6.2
     # via
     #   requests
@@ -58,6 +60,8 @@ requests==2.32.3
     #   facebook-sdk
 six==1.16.0
     # via python-monkey-business
+soupsieve==2.5
+    # via beautifulsoup4
 sqlparse==0.5.0
     # via django
 twitter==1.19.6

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -12,6 +12,8 @@ aspy-refactor-imports==3.0.2
     # via
     #   -r test.txt
     #   seed-isort-config
+beautifulsoup4==4.12.3
+    # via -r test.txt
 certifi==2024.6.2
     # via
     #   -r test.txt
@@ -131,11 +133,18 @@ python-monkey-business==1.0.0
     # via
     #   -r test.txt
     #   django-nested-admin
+pyyaml==6.0.2
+    # via
+    #   -r test.txt
+    #   responses
 requests==2.32.3
     # via
     #   -r test.txt
     #   django-anymail
     #   facebook-sdk
+    #   responses
+responses==0.25.3
+    # via -r test.txt
 seed-isort-config==2.2.0
     # via -r test.txt
 six==1.16.0
@@ -143,6 +152,10 @@ six==1.16.0
     #   -r test.txt
     #   python-dateutil
     #   python-monkey-business
+soupsieve==2.5
+    # via
+    #   -r test.txt
+    #   beautifulsoup4
 sqlparse==0.5.0
     # via
     #   -r test.txt
@@ -163,6 +176,7 @@ urllib3==2.2.2
     #   -r test.txt
     #   django-anymail
     #   requests
+    #   responses
 yapf==0.40.2
     # via -r test.txt
 zipp==3.19.2

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -12,6 +12,8 @@ aspy-refactor-imports==3.0.2
     # via
     #   -r test.txt
     #   seed-isort-config
+beautifulsoup4==4.12.3
+    # via -r test.txt
 build==1.2.1
     # via pip-tools
 certifi==2024.6.2
@@ -158,13 +160,19 @@ python-monkey-business==1.0.0
     # via
     #   -r test.txt
     #   django-nested-admin
-pyyaml==6.0.1
-    # via pre-commit
+pyyaml==6.0.2
+    # via
+    #   -r test.txt
+    #   pre-commit
+    #   responses
 requests==2.32.3
     # via
     #   -r test.txt
     #   django-anymail
     #   facebook-sdk
+    #   responses
+responses==0.25.3
+    # via -r test.txt
 seed-isort-config==2.2.0
     # via -r test.txt
 six==1.16.0
@@ -172,6 +180,10 @@ six==1.16.0
     #   -r test.txt
     #   python-dateutil
     #   python-monkey-business
+soupsieve==2.5
+    # via
+    #   -r test.txt
+    #   beautifulsoup4
 sqlparse==0.5.0
     # via
     #   -r test.txt
@@ -195,6 +207,7 @@ urllib3==2.2.2
     #   -r test.txt
     #   django-anymail
     #   requests
+    #   responses
 virtualenv==20.26.2
     # via pre-commit
 wheel==0.43.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,6 +8,8 @@ asgiref==3.8.1
     # via
     #   -r base.txt
     #   django
+beautifulsoup4==4.12.3
+    # via -r base.txt
 certifi==2024.6.2
     # via
     #   -r base.txt
@@ -79,6 +81,10 @@ six==1.16.0
     # via
     #   -r base.txt
     #   python-monkey-business
+soupsieve==2.5
+    # via
+    #   -r base.txt
+    #   beautifulsoup4
 sqlparse==0.5.0
     # via
     #   -r base.txt

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -6,3 +6,4 @@ isort
 pytest-django
 seed-isort-config
 yapf
+responses

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,6 +10,8 @@ asgiref==3.8.1
     #   django
 aspy-refactor-imports==3.0.2
     # via seed-isort-config
+beautifulsoup4==4.12.3
+    # via -r base.txt
 certifi==2024.6.2
     # via
     #   -r base.txt
@@ -103,11 +105,16 @@ python-monkey-business==1.0.0
     # via
     #   -r base.txt
     #   django-nested-admin
+pyyaml==6.0.2
+    # via responses
 requests==2.32.3
     # via
     #   -r base.txt
     #   django-anymail
     #   facebook-sdk
+    #   responses
+responses==0.25.3
+    # via -r test.in
 seed-isort-config==2.2.0
     # via -r test.in
 six==1.16.0
@@ -115,6 +122,10 @@ six==1.16.0
     #   -r base.txt
     #   python-dateutil
     #   python-monkey-business
+soupsieve==2.5
+    # via
+    #   -r base.txt
+    #   beautifulsoup4
 sqlparse==0.5.0
     # via
     #   -r base.txt
@@ -134,6 +145,7 @@ urllib3==2.2.2
     #   -r base.txt
     #   django-anymail
     #   requests
+    #   responses
 yapf==0.40.2
     # via -r test.in
 zipp==3.19.2


### PR DESCRIPTION
As per https://github.com/orangespaceman/phx/issues/68 I was originally planning to populate the Athlete Model by bulk importing an export from Clubtrac. However, I realised that if you use the Power Of 10 Athlete search feature and specify the club name and  a single letter surname you can find all the Phoenix athletes who's surname begins with that letter. Repeat for the other 25 letters of the alphabet and you have all the Phoenix athletes!

![image](https://github.com/user-attachments/assets/ded558a0-0038-4501-bae7-28389be86b7b)
 
That's what this PR does - introduces a weekly job that would search by every letter of the alphabet to find new Phoenix athletes.

I tested it locally and it scrapes 1133 athletes at the moment:

![image](https://github.com/user-attachments/assets/7d41cee6-2231-4951-8443-f80f9fcc20ab)

The reason this is higher than the ~600 members we currently have is that some people may have left Phoenix but not joined another club and therefore still appear when you search for Phoenix.

The next step, on a weekly basis, would be to scrape the profile page of each Phoenix athlete and store any recent results we haven't seen before. If we detect that someone hasn't run for X years (2?) we can mark them as inactive and no-longer attempt to scrape results for them (or do so on a less frequent cadence). To avoid spamming Power Of 10 too much we can batch up the athletes so that, for example, we only scrape profiles 50 per day.

This PR looks big but most of it is the test HTML file for the Po10 athlete search page