### PR TITLE
Save Performances and Events in database (3)

### DIFF
--- a/phx/performances/tests/test_performances_scraper.py
+++ b/phx/performances/tests/test_performances_scraper.py
@@ -5,6 +5,7 @@ import responses
 from athletes.models import Athlete
 from django.test import TestCase
 from faker import Faker
+from performances.models import Event, Performance
 from performances.performances_scraper import PerformancesScraper
 
 fake = Faker()
@@ -93,6 +94,54 @@ class TestPerformancesScraper(TestCase):
         scraper.find_performances(athlete, datetime.date(2024, 1, 1))
 
         self.assertEqual('5678', scraper.events['5678'].power_of_10_meeting_id)
+
+    @responses.activate
+    def test_extracts_time_as_timedelta(self):
+        athlete = Athlete(power_of_10_id='1234',
+                          created_date=datetime.datetime(2024, 5, 1))
+
+        self.setup_profile_page([{
+            "year":
+            2024,
+            "club":
+            "Brighton Phoenix",
+            "performances": [{
+                "date": "1 May 24",
+                "meeting_id": '5555',
+                "time": "1:20:30.40"
+            }, {
+                "date": "1 May 24",
+                "meeting_id": '6666',
+                "time": "20:30.40"
+            }, {
+                "date": "1 May 24",
+                "meeting_id": '7777',
+                "time": "30.40"
+            }]
+        }])
+
+        scraper = PerformancesScraper()
+
+        scraper.find_performances(athlete, datetime.date(2024, 1, 1))
+
+        perf_1 = scraper.performances[0]
+        perf_2 = scraper.performances[1]
+        perf_3 = scraper.performances[2]
+
+        self.assertEqual(
+            perf_1.time,
+            datetime.timedelta(hours=1,
+                               minutes=20,
+                               seconds=30,
+                               milliseconds=400))
+        self.assertEqual(
+            perf_2.time,
+            datetime.timedelta(minutes=20, seconds=30, milliseconds=400))
+
+        self.assertEqual(
+            perf_3.time,
+            datetime.timedelta(seconds=30, milliseconds=400),
+        )
 
     @responses.activate
     def test_considers_athelete_with_no_recent_performances_inactive(self):
@@ -200,24 +249,97 @@ class TestPerformancesScraper(TestCase):
         pass
 
     @responses.activate
-    def test_save_stores_new_meetings_in_database(self):
-        pass
-
-    @responses.activate
     def test_save_stores_new_performances_in_database(self):
-        pass
+        athlete = Athlete(power_of_10_id='1234')
 
-    @responses.activate
-    def test_save_updates_existing_meetings_in_database(self):
-        pass
+        athlete.save()
+        athlete.created_date = datetime.datetime(2024, 1, 1)
+
+        self.setup_profile_page([{
+            "year":
+            2024,
+            "club":
+            "Brighton Phoenix",
+            "performances": [{
+                "date": "1 May 24",
+                "meeting_id": '5678'
+            }]
+        }])
+
+        scraper = PerformancesScraper()
+        scraper.find_performances(athlete, datetime.date(2024, 1, 1))
+        scraper.save()
+
+        self.assertEqual(1, len(Performance.objects.all()))
+        self.assertEqual(1, len(Event.objects.all()))
 
     @responses.activate
     def test_save_updates_existing_performances_in_database(self):
-        pass
+        athlete = Athlete(power_of_10_id='1234')
+
+        athlete.save()
+        athlete.created_date = datetime.datetime(2024, 1, 1)
+
+        event = Event(name='parkrun',
+                      location='Preston Park',
+                      power_of_10_meeting_id='5678')
+        event.save()
+
+        performance = Performance(athlete=athlete,
+                                  event=event,
+                                  date=datetime.date(2024, 5, 1),
+                                  category='MV35',
+                                  distance='parkrun',
+                                  overall_position=1,
+                                  round='',
+                                  time=datetime.timedelta(minutes=20))
+
+        performance.save()
+
+        self.setup_profile_page([{
+            "year":
+            2024,
+            "club":
+            "Brighton Phoenix",
+            "performances": [{
+                "date": "1 May 24",
+                "meeting_id": '5678',
+                "distance": "parkrun",
+                "round": ''
+            }]
+        }])
+
+        scraper = PerformancesScraper()
+        scraper.find_performances(athlete, datetime.date(2024, 1, 1))
+        scraper.save()
+
+        self.assertEqual(1, len(Performance.objects.all()))
+        self.assertEqual(1, len(Event.objects.all()))
 
     @responses.activate
     def test_save_updates_the_status_of_inactive_athletes(self):
-        pass
+        athlete = Athlete(power_of_10_id='1234')
+
+        athlete.save()
+        athlete.created_date = datetime.datetime(2024, 5, 1)
+
+        self.setup_profile_page([{
+            "year":
+            2022,
+            "club":
+            "Brighton Phoenix",
+            "performances": [{
+                "date": "1 May 22",
+                "meeting_id": 5678
+            }]
+        }])
+
+        scraper = PerformancesScraper()
+
+        scraper.find_performances(athlete, datetime.date(2024, 1, 1))
+        scraper.save()
+
+        self.assertFalse(Athlete.objects.all()[0].active)
 
     def setup_profile_page(self, performances):
         rows = []


### PR DESCRIPTION
This PR actually starts to persist the data into the database. 

Looks a bit like:

![Screenshot from 2024-08-17 20-53-44](https://github.com/user-attachments/assets/14ed5054-6dad-4b69-8d8d-26f6db07f40e)

![image](https://github.com/user-attachments/assets/e2ccfc1d-86c7-4b4e-85ad-2bc0c8feb059)
