### PR TITLE
Optionally exclude parkruns from performances (4)

### DIFF
--- a/phx/performances/performances_scraper.py
+++ b/phx/performances/performances_scraper.py
@@ -16,10 +16,11 @@ class PerformancesScraper:
     ATHLETE_PROFILE_URL = "https://www.thepowerof10.info/athletes/" \
                           "profile.aspx?athleteid={athlete_id}&viewby=date"
 
-    def __init__(self):
+    def __init__(self, include_parkrun=True):
         self.events = {}
         self.performances = []
         self.inactive_athletes = set[str]()
+        self.include_parkrun = include_parkrun
 
     def find_performances(self, athlete: Athlete, since: date):
         """
@@ -93,6 +94,9 @@ class PerformancesScraper:
 
             # Irrelevant row
             if not performance or not event:
+                continue
+
+            if not self.include_parkrun and performance.distance == 'parkrun':
                 continue
 
             # Performance is too old

--- a/phx/performances/tests/test_performances_scraper.py
+++ b/phx/performances/tests/test_performances_scraper.py
@@ -246,7 +246,35 @@ class TestPerformancesScraper(TestCase):
 
     @responses.activate
     def test_ignores_parkruns(self):
-        pass
+        athlete = Athlete(power_of_10_id='1234',
+                          created_date=datetime.datetime(2024, 1, 1))
+
+        self.setup_profile_page([{
+            "year":
+            2024,
+            "club":
+            "Brighton Phoenix",
+            "performances": [
+                {
+                    "date": "1 May 24",
+                    "meeting_id": '5555',
+                    "distance": "parkrun"
+                },
+                {
+                    "date": "1 Apr 24",
+                    "meeting_id": '6666',
+                    "distance": "5K"
+                },
+            ]
+        }])
+
+        scraper = PerformancesScraper(include_parkrun=False)
+
+        count = scraper.find_performances(athlete, datetime.date(2024, 4, 1))
+
+        self.assertEqual(1, count)
+        self.assertEqual(1, len(scraper.events))
+        self.assertEqual(1, len(scraper.performances))
 
     @responses.activate
     def test_save_stores_new_performances_in_database(self):


### PR DESCRIPTION
In order to keep things simple to begin with I thought it would make sense to make including parkruns optional. Initially will run with this set to False but can update it later if we want to / aren't concerned by the increased amount of performances