### PR TITLE
Add an action to make it easy to create results from events (8)

### DIFF
--- a/phx/results/admin.py
+++ b/phx/results/admin.py
@@ -5,6 +5,17 @@ from phx.admin import phx_admin
 from .models import Event, Performance, Result
 
 
+@admin.action(description="Create Results from selected Events")
+def create_result_from_event(_modeladmin, request, queryset):
+    for event in queryset:
+        Result.objects.create(
+            title=f"{event.name} - {event.location}",
+            event_date=event.date,
+            event=event,
+            author=request.user,
+        )
+
+
 class ResultAdmin(admin.ModelAdmin):
     # display data on results listing view
     list_display = ['title', 'event_date', 'author']
@@ -32,6 +43,7 @@ class ResultAdmin(admin.ModelAdmin):
 class EventsAdmin(admin.ModelAdmin):
     list_display = ['name', 'display_new', 'location', 'date']
     exclude = ['uploaded_by']
+    actions = [create_result_from_event]
 
     def save_model(self, request, obj, form, change):
         if getattr(obj, 'uploaded_by', None) is None:


### PR DESCRIPTION
Final PR in this stack, adding an action to make it easy to turn an Event into a Result.

[Screencast from 24-08-24 20:53:22.webm](https://github.com/user-attachments/assets/f850afd5-0d9a-4a3c-bb2f-369c49bff664)

Idea being that each week someone would just need to check the Event admin interface for any "New" events and select the ones that haven't had results pages manually created already.

