### PR TITLE
Skip invalid performances (e.g. DNF, DNS)

### DIFF
--- a/phx/athletes/admin.py
+++ b/phx/athletes/admin.py
@@ -6,7 +6,10 @@ from .models import Athlete
 
 
 class AthleteAdmin(admin.ModelAdmin):
-    list_display = ['first_name', 'last_name', 'gender', 'age_category']
+    list_display = [
+        'first_name', 'last_name', 'gender', 'age_category', 'active',
+        'last_checked'
+    ]
     exclude = ['uploaded_by']
 
     def save_model(self, request, obj, form, change):

--- a/phx/results/performances_scraper.py
+++ b/phx/results/performances_scraper.py
@@ -134,7 +134,7 @@ class PerformancesScraper:
 
         cells = row.find_all('td')
 
-        if len(cells) == 12:
+        if len(cells) == 12 and self._is_valid_performance(cells, athlete):
             po10_id = self._parse_meeting_id(cells[9])
             perf_date = datetime.strptime(cells[11].text.strip(), "%d %b %y")
 
@@ -156,6 +156,15 @@ class PerformancesScraper:
             return (performance, event)
 
         return (None, None)
+
+    def _is_valid_performance(self, cells, athlete: Athlete):
+        time = cells[1].text.strip()
+        position = cells[5].text.strip()
+        if time in ('DNF', 'DNS') or position == '-':
+            logger.warning(f"Skipping invalid performance for {athlete}")
+            return False
+
+        return True
 
     def save(self):
         events = Event.objects.bulk_create(

--- a/phx/results/tests/test_performances_scraper.py
+++ b/phx/results/tests/test_performances_scraper.py
@@ -388,6 +388,38 @@ class TestPerformancesScraper(TestCase):
 
         self.assertFalse(Athlete.objects.all()[0].active)
 
+    @responses.activate
+    def test_ignores_results_without_position(self):
+        athlete = Athlete(power_of_10_id='1234',
+                          created_date=datetime.datetime(2024, 1, 1))
+
+        self.setup_profile_page([{
+            "year":
+            2024,
+            "club":
+            "Brighton Phoenix",
+            "performances": [
+                {
+                    "date": "1 May 24",
+                    "meeting_id": "1234",
+                    "position": "-",
+                    "time": "DNF"
+                },
+                {
+                    "date": "1 Apr 24",
+                    "meeting_id": "5678"
+                },
+            ]
+        }])
+
+        scraper = PerformancesScraper()
+
+        count = scraper.find_performances(athlete, datetime.date(2024, 4, 1))
+
+        self.assertEqual(1, count)
+        self.assertEqual(1, len(scraper.events))
+        self.assertEqual(1, len(scraper.performances))
+
     def setup_profile_page(self, performances):
         rows = []
         for group in performances:


### PR DESCRIPTION
Prevents the scraper from erroring when we encounter a performance without a position or time