### PR TITLE
Scrape parkrun performances and group under same Result (3)

### DIFF
--- a/frontend/components/global/Result/Result.html
+++ b/frontend/components/global/Result/Result.html
@@ -27,6 +27,9 @@
     {{result.results|highlight:search|safe}}
   </p>
   {% for event in result.event_set.all %}
+    {% if result.event_set.all|length > 1 %}
+      <h4 class="Result-eventTitle">{{event.name}}</h4>
+    {% endif %}
   <p class="Result-event">
     <table>
         <tr>

--- a/phx/results/jobs/daily/update_performances.py
+++ b/phx/results/jobs/daily/update_performances.py
@@ -41,7 +41,7 @@ class Job(DailyJob):
         logger.info(f"{len(athletes)} athletes left to check this week")
         logger.info(f"Checking {len(athletes_to_check)} athletes today")
 
-        scraper = PerformancesScraper(include_parkrun=False)
+        scraper = PerformancesScraper(include_parkrun=True)
 
         for athlete in athletes_to_check:
             scraper.find_performances(athlete, since=last_month.date())

--- a/phx/results/performances_scraper.py
+++ b/phx/results/performances_scraper.py
@@ -198,10 +198,18 @@ class PerformancesScraper:
 
         with transaction.atomic():
             for event in events_without_results:
-                event.result = Result.objects.create(
-                    title=f"{event.name} - {event.location}",
-                    event_date=event.date,
-                    draft=True)
-                event.save()
+                if "parkrun" in event.name.lower():
+                    _year, week, _day = event.date.isocalendar()
+                    result, _created = Result.objects.get_or_create(
+                        title=f"parkrun - week {week}", event_date=event.date)
+
+                    event.result = result
+                    event.save()
+                else:
+                    event.result = Result.objects.create(
+                        title=f"{event.name} - {event.location}",
+                        event_date=event.date,
+                        draft=True)
+                    event.save()
 
         return len(performances), len(events), inactive_athletes


### PR DESCRIPTION
Starts scraping parkrun results but rather than publishing each result within a single Result we group all the parkruns from the same week of the year together.

Example

![image](https://github.com/user-attachments/assets/ac987b93-eb9d-4522-9935-0b0d5aafaadf)
