### PR TITLE
Don't render manually created results if field is None

### DIFF
--- a/frontend/components/global/Result/Result.html
+++ b/frontend/components/global/Result/Result.html
@@ -23,9 +23,11 @@
       {{result.summary|highlight:search|safe}}
     </div>
   </div>
+  {% if result.results %}
   <p class="Result-results">
     {{result.results|highlight:search|safe}}
   </p>
+  {% endif %}
   {% for event in result.event_set.all %}
     {% if result.event_set.all|length > 1 %}
       <h4 class="Result-eventTitle">{{event.name}}</h4>


### PR DESCRIPTION
Prevent this:

![image](https://github.com/user-attachments/assets/ef951d1d-0ef0-4c89-86ec-e3df9a429f70)
