### PR TITLE
Fix error when highlight search results

### DIFF
--- a/phx/phx/templatetags/highlight.py
+++ b/phx/phx/templatetags/highlight.py
@@ -6,7 +6,7 @@ register = template.Library()
 @register.filter
 def highlight(full_text, search_term):
     """Wraps all values of search_term"""
-    if len(search_term) == 0:
+    if full_text is None or len(search_term) == 0:
         return full_text
     replacement_text = '{}{}{}'.format('<span class="u-highlight">',
                                        search_term, '</span>')

--- a/phx/phx/tests/templatetags/test_highlight.py
+++ b/phx/phx/tests/templatetags/test_highlight.py
@@ -41,3 +41,12 @@ class TestTemplateTagsHighlight(TestCase):
         results = highlight(full_text, search_term)
 
         self.assertEqual(results, expected)
+
+    def test_None_text_dont_replace_text(self):
+        """
+        Text is missing, don't attempt replace.
+        """
+
+        results = highlight(None, 'foo bar')
+
+        self.assertEqual(results, None)


### PR DESCRIPTION
Fixes:

```
...
  File "/home/phx/phx/env/lib/python3.10/site-packages/django/template/base.py", line 737, in resolve
    new_obj = func(obj, *arg_vals)
  File "/home/phx/phx/phx/phx/templatetags/highlight.py", line 13, in highlight
    return full_text.replace(search_term, replacement_text)

Exception Type: AttributeError at /results/
Exception Value: 'NoneType' object has no attribute 'replace'
Raised during: results.views.ResultsListView
```

Problem is the content of the "results" field can now be None so when we try to highlight parts of it which match the search query it failed.

Note: https://github.com/orangespaceman/phx/pull/103 would also have fixed because with that change we no-longer render the results field if it's None but this is a bit more explicit