### PR TITLE
Convert update_performances to an hourly job

### DIFF
--- a/phx/results/jobs/hourly/update_performances.py
+++ b/phx/results/jobs/hourly/update_performances.py
@@ -5,35 +5,31 @@ from datetime import datetime, timedelta
 
 from athletes.models import Athlete
 from django.db.models import Q
-from django_extensions.management.jobs import DailyJob
+from django_extensions.management.jobs import HourlyJob
 from results.performances_scraper import PerformancesScraper
 
 logger = logging.getLogger(__name__)
 
 
-class Job(DailyJob):
+class Job(HourlyJob):
     help = "Scape the Power of 10 profiles of all Phoenix" \
-           "athletes to find new performances"
+           "athletes to find new performances. Runs each" \
+           "hour between 6am and 10pm every Wednesday"
 
-    MAX_ATHLETES_PER_DAY = 100
+    MAX_ATHLETES_PER_HOUR = 100
 
     def execute(self):
         now = datetime.now()
-        weekday = now.weekday()
-        fraction_to_check = 1 / (7 - weekday)
+        fraction_to_check = fraction_to_check = self.fraction_to_check(now)
 
         last_month = now - timedelta(days=30)
-        last_week = now - timedelta(days=weekday + 1)
-        last_week = last_week.replace(hour=23,
-                                      minute=59,
-                                      second=59,
-                                      microsecond=0)
+        midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
 
-        athletes = Athlete.objects.filter(Q(last_checked__lt=last_week)
+        athletes = Athlete.objects.filter(Q(last_checked__lt=midnight)
                                           | Q(last_checked__isnull=True),
                                           active=True)
         num_to_check = math.ceil(
-            min(self.MAX_ATHLETES_PER_DAY,
+            min(self.MAX_ATHLETES_PER_HOUR,
                 len(athletes) * fraction_to_check))
 
         athletes_to_check = random.sample(list(athletes), num_to_check)
@@ -52,3 +48,10 @@ class Job(DailyJob):
         logger.info(f"{performances} performances updated")
         logger.info(f"{events} events updated")
         logger.info("Job complete")
+
+    @staticmethod
+    def fraction_to_check(time: datetime) -> float:
+        if time.hour < 6 or time.hour >= 22:
+            return 0
+
+        return 1 / (22 - time.hour)

--- a/phx/results/tests/test_update_performances.py
+++ b/phx/results/tests/test_update_performances.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+
+import pytest
+from results.jobs.hourly.update_performances import Job as UpdatePerformances
+
+
+@pytest.mark.parametrize(
+    "hour, fraction",
+    [
+        # between midnight and 6am no athletes should be checked
+        (0, 0),
+        (1, 0),
+        (2, 0),
+        (3, 0),
+        (4, 0),
+        (5, 0),
+        # between 6am and 10pm 1/16 of athletes should be checked each hour
+        (6, 1 / 16),
+        (7, 1 / 15),
+        (8, 1 / 14),
+        (9, 1 / 13),
+        (10, 1 / 12),
+        (11, 1 / 11),
+        (12, 1 / 10),
+        (13, 1 / 9),
+        (14, 1 / 8),
+        (15, 1 / 7),
+        (16, 1 / 6),
+        (17, 1 / 5),
+        (18, 1 / 4),
+        (19, 1 / 3),
+        (20, 1 / 2),
+        (21, 1 / 1),
+        # after 10pm no athletes should be checked
+        (22, 0),
+        (23, 0)
+    ])
+def test_fraction_to_check(hour, fraction):
+
+    time = datetime.now().replace(hour=hour)
+
+    assert UpdatePerformances.fraction_to_check(time) == fraction


### PR DESCRIPTION
Updates the performance scraper to run hourly but to do nothing between 10pm and 6am the next day 

Probably won'f trigger the job to run every day to begin with, probably just every hour on a Wednesday (0 * * * 3)

We currently have 541 active athletes so we'll end up checking ~34 every hour