### PR TITLE
Support exporting performancs in Clubtrac format (#80)

### DIFF
--- a/phx/phx/settings/app.py
+++ b/phx/phx/settings/app.py
@@ -31,6 +31,7 @@ INSTALLED_APPS = [
     'django_extensions',
     'ckeditor',
     'admin_ordering',
+    'import_export',
 
     # PHX
     'components.apps.ComponentsConfig',

--- a/phx/results/admin.py
+++ b/phx/results/admin.py
@@ -1,4 +1,8 @@
 from django.contrib import admin
+from import_export import resources
+from import_export.admin import ExportActionMixin
+from import_export.fields import Field
+from import_export.widgets import DateWidget, Widget
 
 from phx.admin import phx_admin
 
@@ -66,9 +70,60 @@ class EventsAdmin(admin.ModelAdmin):
         obj.save()
 
 
-class PerformancesAdmin(admin.ModelAdmin):
+class GenderWidget(Widget):
+
+    def render(self, value, obj=None):
+        if value == 'W':
+            return 'Female'
+
+        if value == 'M':
+            return 'Male'
+
+        return ''
+
+
+class PerformanceResource(resources.ModelResource):
+    athlete__first_name = Field(attribute='athlete__first_name',
+                                column_name='First Name')
+    athlete__last_name = Field(attribute='athlete__last_name',
+                               column_name='Last Name')
+    distance = Field(attribute='distance', column_name='Event Distance')
+    overall_position = Field(attribute='overall_position',
+                             column_name='Position')
+    athlete__age_category = Field(attribute='athlete__age_category',
+                                  column_name='Age Category')
+    date = Field(attribute='date',
+                 column_name='Event Date',
+                 widget=DateWidget('%d/%m/%Y'))
+    athlete__gender = Field(attribute='athlete__gender',
+                            column_name='Sex',
+                            widget=GenderWidget())
+    age_position = Field(attribute='age_position',
+                         column_name='Age Category Position')
+    gender_position = Field(attribute='gender_position',
+                            column_name='Gender Position')
+    event__name = Field(attribute='event__name', column_name='Event Name')
+
+    class Meta:
+        model = Performance
+        fields = (
+            'athlete__first_name',
+            'athlete__last_name',
+            'distance',
+            'overall_position',
+            'athlete__age_category',
+            'date',
+            'athlete__gender',
+            'age_position',
+            'gender_position',
+            'event__name',
+        )
+
+
+class PerformancesAdmin(ExportActionMixin, admin.ModelAdmin):
     list_display = ['athlete', 'event', 'distance', 'time']
     exclude = ['uploaded_by']
+    resource_classes = [PerformanceResource]
 
     def save_model(self, request, obj, form, change):
         if getattr(obj, 'uploaded_by', None) is None:

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,6 +5,7 @@ django-anymail[mailgun]
 django-ckeditor
 django-environ
 django-nested-admin
+django-import-export
 easy-thumbnails
 facebook-sdk
 psycopg2-binary

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,12 +14,15 @@ certifi==2024.7.4
     #   twitter
 charset-normalizer==3.3.2
     # via requests
+diff-match-patch==20230430
+    # via django-import-export
 django==5.0.8
     # via
     #   -r base.in
     #   django-anymail
     #   django-ckeditor
     #   django-extensions
+    #   django-import-export
     #   django-js-asset
     #   easy-thumbnails
 django-admin-ordering==0.18.0
@@ -31,6 +34,8 @@ django-ckeditor==6.7.1
 django-environ==0.11.2
     # via -r base.in
 django-extensions==3.2.3
+    # via -r base.in
+django-import-export==4.1.1
     # via -r base.in
 django-js-asset==2.2.0
     # via
@@ -64,6 +69,8 @@ soupsieve==2.5
     # via beautifulsoup4
 sqlparse==0.5.0
     # via django
+tablib==3.5.0
+    # via django-import-export
 twitter==1.19.6
     # via -r base.in
 typing-extensions==4.12.1

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -23,12 +23,17 @@ charset-normalizer==3.3.2
     # via
     #   -r test.txt
     #   requests
+diff-match-patch==20230430
+    # via
+    #   -r test.txt
+    #   django-import-export
 django==5.0.8
     # via
     #   -r test.txt
     #   django-anymail
     #   django-ckeditor
     #   django-extensions
+    #   django-import-export
     #   django-js-asset
     #   easy-thumbnails
     #   factory-djoy
@@ -41,6 +46,8 @@ django-ckeditor==6.7.1
 django-environ==0.11.2
     # via -r test.txt
 django-extensions==3.2.3
+    # via -r test.txt
+django-import-export==4.1.1
     # via -r test.txt
 django-js-asset==2.2.0
     # via
@@ -160,6 +167,10 @@ sqlparse==0.5.0
     # via
     #   -r test.txt
     #   django
+tablib==3.5.0
+    # via
+    #   -r test.txt
+    #   django-import-export
 tomli==2.0.1
     # via
     #   -r test.txt

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -29,6 +29,10 @@ charset-normalizer==3.3.2
     #   requests
 click==8.1.7
     # via pip-tools
+diff-match-patch==20230430
+    # via
+    #   -r test.txt
+    #   django-import-export
 distlib==0.3.8
     # via virtualenv
 django==5.0.8
@@ -38,6 +42,7 @@ django==5.0.8
     #   django-ckeditor
     #   django-debug-toolbar
     #   django-extensions
+    #   django-import-export
     #   django-js-asset
     #   easy-thumbnails
     #   factory-djoy
@@ -52,6 +57,8 @@ django-debug-toolbar==4.4.2
 django-environ==0.11.2
     # via -r test.txt
 django-extensions==3.2.3
+    # via -r test.txt
+django-import-export==4.1.1
     # via -r test.txt
 django-js-asset==2.2.0
     # via
@@ -189,6 +196,10 @@ sqlparse==0.5.0
     #   -r test.txt
     #   django
     #   django-debug-toolbar
+tablib==3.5.0
+    # via
+    #   -r test.txt
+    #   django-import-export
 tomli==2.0.1
     # via
     #   -r test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -19,12 +19,17 @@ charset-normalizer==3.3.2
     # via
     #   -r base.txt
     #   requests
+diff-match-patch==20230430
+    # via
+    #   -r base.txt
+    #   django-import-export
 django==5.0.8
     # via
     #   -r base.txt
     #   django-anymail
     #   django-ckeditor
     #   django-extensions
+    #   django-import-export
     #   django-js-asset
     #   easy-thumbnails
 django-admin-ordering==0.18.0
@@ -36,6 +41,8 @@ django-ckeditor==6.7.1
 django-environ==0.11.2
     # via -r base.txt
 django-extensions==3.2.3
+    # via -r base.txt
+django-import-export==4.1.1
     # via -r base.txt
 django-js-asset==2.2.0
     # via
@@ -89,6 +96,10 @@ sqlparse==0.5.0
     # via
     #   -r base.txt
     #   django
+tablib==3.5.0
+    # via
+    #   -r base.txt
+    #   django-import-export
 twitter==1.19.6
     # via -r base.txt
 typing-extensions==4.12.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -21,12 +21,17 @@ charset-normalizer==3.3.2
     # via
     #   -r base.txt
     #   requests
+diff-match-patch==20230430
+    # via
+    #   -r base.txt
+    #   django-import-export
 django==5.0.8
     # via
     #   -r base.txt
     #   django-anymail
     #   django-ckeditor
     #   django-extensions
+    #   django-import-export
     #   django-js-asset
     #   easy-thumbnails
     #   factory-djoy
@@ -39,6 +44,8 @@ django-ckeditor==6.7.1
 django-environ==0.11.2
     # via -r base.txt
 django-extensions==3.2.3
+    # via -r base.txt
+django-import-export==4.1.1
     # via -r base.txt
 django-js-asset==2.2.0
     # via
@@ -130,6 +137,10 @@ sqlparse==0.5.0
     # via
     #   -r base.txt
     #   django
+tablib==3.5.0
+    # via
+    #   -r base.txt
+    #   django-import-export
 tomli==2.0.1
     # via
     #   pytest


### PR DESCRIPTION
Uses the django-import-export app to support Mike's request of exporting data in the Clubtrac format (#80)

You can select the performances to export, or export everything

![Screenshot from 2024-09-06 20-58-55](https://github.com/user-attachments/assets/5fea7d3f-518e-4853-9fa5-2e6e48c6edaf)

![Screenshot from 2024-09-06 20-58-31](https://github.com/user-attachments/assets/75481a64-0382-46e8-b78f-0cc3b4a2fc51)
