### PR TITLE
Don't mark newly transferred members as inactive

### DIFF
--- a/phx/results/tests/test_body.html
+++ b/phx/results/tests/test_body.html
@@ -131,7 +131,7 @@
                                     <table width="100%" cellspacing="0" cellpadding="0">
                                         <tr>
                                             <td width="50%" valign="top">
-                                                <table cellspacing="0" cellpadding="2"><tr><td><b>Club:</b></td><td>Brighton Phoenix</td></tr><tr><td><b>Gender:</b></td><td>Male</td></tr><tr><td><b>Age Group:</b></td><td>V35</td></tr><tr><td><b>County:</b></td><td>Sussex</td></tr><tr><td><b>Region:</b></td><td>South East</td></tr><tr><td><b>Nation:</b></td><td>England</td></tr></table>
+                                                <table cellspacing="0" cellpadding="2"><tr><td><b>Club:</b></td><td>{current_club}</td></tr><tr><td><b>Gender:</b></td><td>Male</td></tr><tr><td><b>Age Group:</b></td><td>V35</td></tr><tr><td><b>County:</b></td><td>Sussex</td></tr><tr><td><b>Region:</b></td><td>South East</td></tr><tr><td><b>Nation:</b></td><td>England</td></tr></table>
                                             </td>
                                             <td width="50%" valign="top">
                                                 <table cellspacing="0" cellpadding="2"><tr><td><b>Lead Coach:</b></td><td>Unknown</td></tr></table>


### PR DESCRIPTION
If an athlete joins from another club and hasn't yet competed for Phoenix the current logic will incorrectly mark them as inactive.

Fix is to check the current club according to the athlete details section rather than whether they have any recent performances for phoenix

Recent example where we incorrectly marked someone who just joined the club as inactive:

![image](https://github.com/user-attachments/assets/9545b788-38bb-498d-a42f-f81d3cf3b9cc)
