### PR TITLE
Deliberately sort performances in results view (#106)

### DIFF
--- a/phx/results/models.py
+++ b/phx/results/models.py
@@ -106,3 +106,4 @@ class Performance(models.Model):
                 fields=['athlete', 'event', 'distance', 'round'],
                 name='unique_performance')
         ]
+        ordering = ['date', 'distance', 'round', 'time']

--- a/phx/results/tests/test_performances_model.py
+++ b/phx/results/tests/test_performances_model.py
@@ -1,0 +1,72 @@
+from datetime import datetime, timedelta
+
+from athletes.models import Athlete
+from django.test import TestCase
+from results.models import Event, Performance
+
+
+class TestPerformancesModel(TestCase):
+
+    def test_orders_by_date_distance_round_time(self):
+        athlete = Athlete()
+        athlete.save()
+
+        event = Event(name="Open Meet")
+        event.save()
+
+        today = datetime.now()
+        yesterday = today - timedelta(days=1)
+
+        performances = [
+            Performance(event=event,
+                        athlete=athlete,
+                        time=timedelta(minutes=20),
+                        distance="5000",
+                        round="1",
+                        date=today,
+                        overall_position=1),
+            Performance(event=event,
+                        athlete=athlete,
+                        time=timedelta(minutes=18),
+                        distance="5000",
+                        round="2",
+                        date=today,
+                        overall_position=1),
+            Performance(event=event,
+                        athlete=athlete,
+                        time=timedelta(minutes=1),
+                        distance="400",
+                        date=today,
+                        overall_position=1),
+            Performance(event=event,
+                        athlete=athlete,
+                        time=timedelta(minutes=2),
+                        distance="400",
+                        date=today,
+                        overall_position=1),
+            Performance(event=event,
+                        athlete=athlete,
+                        time=timedelta(minutes=3),
+                        distance="400",
+                        date=yesterday,
+                        overall_position=1),
+        ]
+
+        Performance.objects.bulk_create(performances)
+        saved = Performance.objects.all()
+        times = [performance.time for performance in saved]
+
+        self.assertEqual(
+            [
+                # A 400 meters yesterday
+                timedelta(minutes=3),
+                # A 400 meters today - faster than yesterday but a day later
+                timedelta(minutes=1),
+                # A 400 meters today - slower than the other 400 meters today
+                timedelta(minutes=2),
+                # A round 1 5000 meters - distance is 'greater' than 400
+                timedelta(minutes=20),
+                # A round 2 5000 meters - faster 5000 but 'greater' round
+                timedelta(minutes=18),
+            ],
+            times)


### PR DESCRIPTION
Sort by date, distance, round, time

Example

![image](https://github.com/user-attachments/assets/2d59b810-5509-4999-9b5f-b214accf882a)
