### PR TITLE
Make content of Results from Events/Performances searchable (#113)

### DIFF
--- a/frontend/components/global/Result/Result.html
+++ b/frontend/components/global/Result/Result.html
@@ -30,7 +30,7 @@
   {% endif %}
   {% for event in result.event_set.all %}
     {% if result.event_set.all|length > 1 %}
-      <h4 class="Result-eventTitle">{{event.name}}</h4>
+      <h4 class="Result-eventTitle">{{event.name|highlight:search|safe}}</h4>
     {% endif %}
   <p class="Result-event">
     <table>
@@ -43,7 +43,7 @@
         </tr>
         {% for performance in event.performance_set.all %}
           <tr>
-            <td>{{performance.athlete.first_name}} {{performance.athlete.last_name}}</td>
+            <td>{{performance.athlete.full_name|highlight:search|safe}}</td>
             <td>{{performance.category}}</td>
             <td>{{performance.distance}}</td>
             <td>{{performance.overall_position}}</td>

--- a/phx/athletes/models.py
+++ b/phx/athletes/models.py
@@ -25,5 +25,9 @@ class Athlete(models.Model):
         null=True,
     )
 
+    @property
+    def full_name(self) -> str:
+        return f"{self.first_name} {self.last_name}"
+
     def __str__(self) -> str:
         return f"{self.first_name} {self.last_name} ({self.age_category})"

--- a/phx/athletes/tests/factories.py
+++ b/phx/athletes/tests/factories.py
@@ -1,0 +1,19 @@
+from datetime import datetime, timezone
+
+from factory.fuzzy import FuzzyDateTime, FuzzyText
+from factory_djoy import CleanModelFactory
+
+from ..models import Athlete
+
+
+class AthleteFactory(CleanModelFactory):
+    first_name = FuzzyText()
+    last_name = FuzzyText()
+    age_category = FuzzyText(length=3)
+    gender = FuzzyText(length=1)
+    power_of_10_id = FuzzyText()
+    last_checked = FuzzyDateTime(datetime.now(timezone.utc))
+
+    class Meta:
+        model = Athlete
+        skip_postgeneration_save = True

--- a/phx/phx/templatetags/highlight.py
+++ b/phx/phx/templatetags/highlight.py
@@ -1,3 +1,5 @@
+import re
+
 from django import template
 
 register = template.Library()
@@ -8,6 +10,10 @@ def highlight(full_text, search_term):
     """Wraps all values of search_term"""
     if full_text is None or len(search_term) == 0:
         return full_text
-    replacement_text = '{}{}{}'.format('<span class="u-highlight">',
-                                       search_term, '</span>')
-    return full_text.replace(search_term, replacement_text)
+
+    # Use a replacer function in order to maintain the original case
+    def replacer(match):
+        return '<span class="u-highlight">{}</span>'.format(match.group(0))
+
+    pattern = re.compile(re.escape(search_term), re.IGNORECASE)
+    return pattern.sub(replacer, full_text)

--- a/phx/phx/tests/templatetags/test_highlight.py
+++ b/phx/phx/tests/templatetags/test_highlight.py
@@ -50,3 +50,16 @@ class TestTemplateTagsHighlight(TestCase):
         results = highlight(None, 'foo bar')
 
         self.assertEqual(results, None)
+
+    def test_case_insensitive(self):
+        """
+        Case insensitive search
+        """
+        full_text = 'Lorem ipsum dolor sit amet'
+        search_term = 'LOREM'
+        expected = ('<span class="u-highlight">Lorem</span> ipsum '
+                    'dolor sit amet')
+
+        results = highlight(full_text, search_term)
+
+        self.assertEqual(results, expected)

--- a/phx/results/tests/factories.py
+++ b/phx/results/tests/factories.py
@@ -1,10 +1,10 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from factory import post_generation
-from factory.fuzzy import FuzzyDate, FuzzyText
+from factory.fuzzy import FuzzyDate, FuzzyDateTime, FuzzyInteger, FuzzyText
 from factory_djoy import CleanModelFactory
 
-from ..models import Result
+from ..models import Event, Performance, Result
 
 
 class ResultFactory(CleanModelFactory):
@@ -26,4 +26,36 @@ class ResultFactory(CleanModelFactory):
 
     class Meta:
         model = Result
+        skip_postgeneration_save = True
+
+
+class EventFactory(CleanModelFactory):
+    name = FuzzyText()
+    location = FuzzyText()
+    power_of_10_meeting_id = FuzzyText()
+
+    class Meta:
+        model = Event
+        skip_postgeneration_save = True
+
+
+class FuzzyTime(FuzzyDateTime):
+
+    def fuzz(self):
+        return super().fuzz().time()
+
+
+class PerformanceFactory(CleanModelFactory):
+    date = FuzzyDate(datetime.now().date())
+    distance = FuzzyText()
+    category = FuzzyText(length=4)
+    overall_position = FuzzyText(length=2)
+    time = FuzzyDateTime(datetime.now(
+        timezone.utc)).fuzz().strftime('%H:%M:%S')
+    round = FuzzyText(length=1)
+    gender_position = FuzzyInteger(1)
+    age_position = FuzzyInteger(1)
+
+    class Meta:
+        model = Performance
         skip_postgeneration_save = True

--- a/phx/results/tests/views/test_results_view.py
+++ b/phx/results/tests/views/test_results_view.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 
+from athletes.tests.factories import AthleteFactory
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -8,7 +9,7 @@ from fixtures.tests.factories import CategoryFactory
 from pages.models import Page
 
 from ...models import Result
-from ..factories import ResultFactory
+from ..factories import EventFactory, PerformanceFactory, ResultFactory
 
 
 class TestResultsView(TestCase):
@@ -139,6 +140,41 @@ class TestResultsView(TestCase):
 
         response = self.client.get(url, {'search': 'cat 3'})
         self.assertEqual(len(response.context['results']), 0)
+
+    def test_result_athlete_search(self):
+        """
+        GET request retrieves results filtered by search
+        """
+        Page.objects.create(title='results')
+        url = reverse('results-index')
+
+        result = ResultFactory(title='parkrun')
+        john = AthleteFactory(first_name='John', last_name='Doe')
+        jane = AthleteFactory(first_name='Jane', last_name='Doe')
+        event = EventFactory(result=result)
+        PerformanceFactory(athlete=john, event=event)
+        PerformanceFactory(athlete=jane, event=event)
+
+        response = self.client.get(url, {'search': 'john doe'})
+        self.assertEqual(len(response.context['results']), 1)
+
+    def test_result_event_name_search(self):
+        """
+        GET request retrieves results filtered by search
+        """
+        Page.objects.create(title='results')
+        url = reverse('results-index')
+
+        result = ResultFactory(title='parkrun')
+        john = AthleteFactory(first_name='John', last_name='Doe')
+        jane = AthleteFactory(first_name='Jane', last_name='Doe')
+        first_event = EventFactory(name='Preston Park', result=result)
+        second_event = EventFactory(name='Hove Prom', result=result)
+        PerformanceFactory(athlete=john, event=first_event)
+        PerformanceFactory(athlete=jane, event=second_event)
+
+        response = self.client.get(url, {'search': 'Preston'})
+        self.assertEqual(len(response.context['results']), 1)
 
     def test_get_year(self):
         """"


### PR DESCRIPTION
Makes the Results that are created from Events/Performances searchable.

Specifically, searchable by athlete name or event name.

Also makes the highlight template tag case insensitive

![image](https://github.com/user-attachments/assets/ec3c2943-42ef-4e64-9723-8a523a7bc62d)
