### PR TITLE
Don't rely on club in Performances table to determine if result relevant

### DIFF
--- a/phx/results/performances_scraper.py
+++ b/phx/results/performances_scraper.py
@@ -92,10 +92,6 @@ class PerformancesScraper:
             logger.warning(f"{athlete} has no recent performances")
             return (performances, events, False)
 
-        if "Brighton Phoenix" not in rows[0].text:
-            logger.warning(f"{athlete} has no recent Phoenix performances")
-            return (performances, events, True)
-
         for row in rows[1:]:
             (performance, event) = self._parse_row(row, athlete)
 

--- a/phx/results/tests/test_performances_scraper.py
+++ b/phx/results/tests/test_performances_scraper.py
@@ -208,7 +208,7 @@ class TestPerformancesScraper(TestCase):
 
         count = scraper.find_performances(athlete, datetime.date(2024, 1, 1))
 
-        self.assertEqual(0, count)
+        self.assertEqual(1, count)
         self.assertListEqual([], list(scraper.inactive_athletes))
 
     @responses.activate


### PR DESCRIPTION
Previously we would ignore any results if Brighton Phoenix wasn't mentioned in the performances header. It seems this is not reliable though. e.g. James Brewster recently competed for Phoenix at the Barns Green Half Marathon but the table header only shows Arena 80. 

No longer relying on this check and instead using the date that we first discovered they were a Phoenix athlete as the cut-off point.

![Screenshot from 2024-10-12 20-02-27](https://github.com/user-attachments/assets/2cb93bf8-c4dc-46d8-bf57-b6e47ea0b5fc)
