### PR TITLE
Don't crash if profile page empty

### DIFF
--- a/phx/results/performances_scraper.py
+++ b/phx/results/performances_scraper.py
@@ -70,6 +70,11 @@ class PerformancesScraper:
         still_phoenix = "Brighton Phoenix" in current_club
 
         performances = soup.select('div[id$=pnlPerformances]')
+        if not performances:
+            power_of_10_id = athlete.power_of_10_id
+            logger.warning(f"Performances section missing ({power_of_10_id})")
+            return ([], {}, True)  # Assume active in case just temporary issue
+
         tables = performances[0].find_all('table')
 
         rows = self._parse_results_table(tables)

--- a/phx/results/tests/test_performances_scraper.py
+++ b/phx/results/tests/test_performances_scraper.py
@@ -632,6 +632,20 @@ class TestPerformancesScraper(TestCase):
         # the second.
         self.assertEqual((1, 1, 0), scraper.save())
 
+    @responses.activate
+    def test_dont_crash_when_profile_missing(self):
+        athlete = Athlete(power_of_10_id='1234')
+
+        athlete.save()
+        scraper = PerformancesScraper()
+
+        responses.get("https://www.thepowerof10.info/athletes/profile.aspx",
+                      body="<html>Profile not found</html>",
+                      content_type='text/plain',
+                      status=200)
+
+        scraper.find_performances(athlete, datetime.date(2024, 5, 1))
+
     def setup_profile_page(self,
                            performances,
                            current_club="Brighton Phoenix"):


### PR DESCRIPTION
Currently we crash when parsing a page like this:

![image](https://github.com/user-attachments/assets/a04f1076-685a-4bcb-b6be-5132af50db73)

Which could happen because an individual has been removed from PowerOf10