### PR TITLE
Don't show draft results on homepage

### DIFF
--- a/phx/home/tests/views/test_home_view.py
+++ b/phx/home/tests/views/test_home_view.py
@@ -202,6 +202,21 @@ class TestHomeView(TestCase):
         self.assertEqual(response.context['results'][0],
                          Result.objects.first())
 
+    def test_draft_results(self):
+        """
+        Test draft results are not returned
+        """
+
+        url = reverse('home-index')
+        Page.objects.create(title='home')
+        ContentFactory()
+
+        ResultFactory(draft=True)
+
+        response = self.client.get(url)
+
+        self.assertEqual(len(response.context['results']), 0)
+
     def test_news(self):
         """
         Test latest news are returned

--- a/phx/home/views.py
+++ b/phx/home/views.py
@@ -80,8 +80,8 @@ class HomeView(generic.TemplateView):
             '-created_date')[:3]
 
     def get_results(self):
-        return Result.objects.filter(
-            event_date__lte=timezone.now()).order_by('-event_date')[:5]
+        return Result.objects.filter(event_date__lte=timezone.now(),
+                                     draft=False).order_by('-event_date')[:5]
 
     def get_title(self):
         return self.content.title


### PR DESCRIPTION
Currently draft results appear in the homepage widget

![image](https://github.com/user-attachments/assets/6fb1b067-98db-4ae9-843d-19f7f1002744)

We don't want them to