### PR TITLE
Publish Results automatically once all athletes have been checked

### DIFF
--- a/phx/results/performances_scraper.py
+++ b/phx/results/performances_scraper.py
@@ -229,6 +229,26 @@ class PerformancesScraper:
 
         return len(performances), len(events), inactive_athletes
 
+    def publish_results(self):
+        today = datetime.now(tz=timezone.utc).replace(hour=0,
+                                                      minute=0,
+                                                      second=0,
+                                                      microsecond=0)
+
+        # Find all Events that were created today and are
+        # associated with a draft Result
+        events = Event.objects.filter(result__draft=True,
+                                      created_date__gt=today,
+                                      result__created_date__gt=today)
+
+        # Publish the Results of all Events created today
+        for event in events:
+            if event.result:
+                event.result.draft = False
+                event.result.save()
+
+        return len(events)
+
     @staticmethod
     def remove_conflicts(performances):
         seen = set()

--- a/phx/results/performances_scraper.py
+++ b/phx/results/performances_scraper.py
@@ -216,7 +216,9 @@ class PerformancesScraper:
                 if "parkrun" in event.name.lower():
                     _year, week, _day = event.date.isocalendar()
                     result, _created = Result.objects.get_or_create(
-                        title=f"parkrun - week {week}", event_date=event.date)
+                        title=f"parkrun - week {week}",
+                        event_date=event.date,
+                        defaults={"draft": True})
 
                     event.result = result
                     event.save()

--- a/phx/results/tests/test_performances_scraper.py
+++ b/phx/results/tests/test_performances_scraper.py
@@ -426,6 +426,11 @@ class TestPerformancesScraper(TestCase):
                 "meeting_id": '5678',
                 "distance": "5K",
                 "meeting": "Brighton 5K"
+            }, {
+                "date": "2 May 24",
+                "meeting_id": '9999',
+                "distance": "parkrun",
+                "meeting": "Preston Park parkrun"
             }]
         }])
 
@@ -436,13 +441,17 @@ class TestPerformancesScraper(TestCase):
         events = Event.objects.all()
         results = Result.objects.all()
 
-        self.assertEqual(1, len(events))
-        self.assertEqual(1, len(results))
+        self.assertEqual(2, len(events))
+        self.assertEqual(2, len(results))
         self.assertEqual(events[0].result, results[0])
 
         self.assertTrue(results[0].draft)
         self.assertEqual(events[0].date, results[0].event_date)
         self.assertTrue(events[0].name in results[0].title)
+
+        self.assertTrue(results[1].draft)
+        self.assertEqual(events[1].date, results[1].event_date)
+        self.assertEqual("parkrun - week 18", results[1].title)
 
     @responses.activate
     def test_save_doesnt_create_new_result_if_already_exists(self):


### PR DESCRIPTION
Until now we've been creating most Results as "drafts" first and then manually publishing them once we're sure they aren't duplicates. The one exception to this is the parkrun Results which we publish as soon as we have a single Peformance for a particular events.

Since we've been doing it we've only had one duplicate Result that I can recall so I'd like to switch the logic so that we publish automatically and manually un-publish if we see duplicates.

At the same time I think it makes sense NOT to publish parkrun Results as soon as we have a single Performance because this means we "drip-feed" results throughout the day as more members are scrapped.

So from now on we'll treat parkrun and other Results the same and publish automatically each day BUT only once all members have been checked for a particular day